### PR TITLE
Adding toJSON method for Postgres range type so inclusive is not lost

### DIFF
--- a/lib/dialects/postgres/range.js
+++ b/lib/dialects/postgres/range.js
@@ -71,6 +71,13 @@ function parse(value, parser) {
 
   result.inclusive = [value[0] === '[', value[value.length - 1] === ']'];
 
+  result.toJSON = function() {
+    return [
+      {value: result[0], inclusive: value[0] === '['},
+      {value: result[1], inclusive: value[1] === '['},
+    ];
+  };
+  
   return result;
 }
 exports.parse = parse;

--- a/test/integration/dialects/postgres/range.test.js
+++ b/test/integration/dialects/postgres/range.test.js
@@ -224,5 +224,12 @@ if (dialect.match(/^postgres/)) {
         expect(DataTypes.postgres.RANGE.parse(stringified, 3904, () => { return DataTypes.postgres.INTEGER.parse; })).to.deep.equal(testRange);
       });
     });
+    describe('convert to json', () => {
+      it('should return both the value and inclusivity', () => {
+        const data = "[5, 10)";
+        const jsonified = JSON.stringify(DataTypes.postgres.RANGE.parse(data, () => { return DataTypes.postgres.INTEGER.parse; });
+        expect(jsonified).to.deep.equal([{value: 5, inclusive: true}, {value: 10, inclusive: false}]);
+      });
+    });
   });
 }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Did you follow the commit message conventions explained in CONTRIBUTING.md?

I tried to run the tests but it is throwing an "undefined" error before it even gets to my new test:

![conemu64_2017-10-12_22-11-38](https://user-images.githubusercontent.com/2287252/31531184-5cc89e04-af9a-11e7-9e4f-29342b85a75d.png)


### Description of change

This is possibly a BC break if people are relying on the JSON format to just be dates. I could alter it so the first two entries in the array are the dates for BC? As it is right now, the date range is missing the inclusiveness which is like using a time without knowing what timezone it is. 

Issue this fixes: https://github.com/sequelize/sequelize/issues/8471
